### PR TITLE
fix header's display bug on Safari

### DIFF
--- a/src/style/Header.module.scss
+++ b/src/style/Header.module.scss
@@ -76,7 +76,7 @@
   @media only screen and (min-width: $sm) {
     display: flex;
     grid-area: pc-mode-route;
-    height: 100%;
+    height: 64px;
     justify-content: flex-start;
     padding: {
       bottom: 0;


### PR DESCRIPTION
Manually set the header's component's height.